### PR TITLE
fixes #629: Property types in dashboard are sortable

### DIFF
--- a/lib/resources/collection/dashboard/properties.html
+++ b/lib/resources/collection/dashboard/properties.html
@@ -84,7 +84,7 @@
       <span class="caret"></span>
     </a>
     <ul class="dropdown-menu" data-bind="foreach: $root.propertyTypes">
-      <li data-bind="css: {active: $parent.type() == id}, popover: {placement: 'right', title: label, content: tooltip}">
+      <li data-bind="css: {active: $parent.type() == id}, popover: {placement: 'right', title: label, content: tooltip}" class="locked">
         <a href="#" data-bind="click: $parent.setType">
           <i class="icon-custom" data-bind="cssNamed: id"></i>&nbsp;
           <span data-bind="text:label"></span></a>


### PR DESCRIPTION
Adds class "locked" to list items that should not be sortable.